### PR TITLE
Fix for episodes with german umlauts in title

### DIFF
--- a/southpark.py
+++ b/southpark.py
@@ -435,7 +435,7 @@ class SouthParkAddon(object):
 		show_subs = self.options.show_subtitles()
 		for i in range(0, parts):
 			playitem = xbmcgui.ListItem(path=streams[i])
-			title = data["title"]
+			title = data["title"].encode("utf-8")
 			if len(streams) > 1:
 				title = "{title} ({i}/{n})".format(title=title, i=(i + 1), n=parts)
 


### PR DESCRIPTION
Fix for umlauts. Perhaps also necessary for master branch and python 3, but couldn't test it.

Original error message:
```
ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.UnicodeEncodeError'>
                                            Error Contents: 'ascii' codec can't encode character u'\xdf' in position 7: ordinal not in range(128)
                                            Traceback (most recent call last):
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.southpark_unofficial/default.py", line 9, in <module>
                                                plugin.handle()
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.southpark_unofficial/southpark.py", line 476, in handle
                                                self.play_episode(kodi.PARAM_SEASON, kodi.PARAM_EPISODE)
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.southpark_unofficial/southpark.py", line 440, in play_episode
                                                title = "{title} ({i}/{n})".format(title=title, i=(i + 1), n=parts)
                                            UnicodeEncodeError: 'ascii' codec can't encode character u'\xdf' in position 7: ordinal not in range(128)
                                            -->End of Python script error report<--
```